### PR TITLE
Moved a few functions from `vim::api` out of unstable feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvim-utils"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Utilities for writing neovim plugins in rust"
 authors = ["Will Hopkins <willothyh@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Using `nvim-utils` is as simple as adding it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nvim-utils = "0.1.3"
+nvim-utils = "0.1.4"
 ```
 
 or

--- a/src/vim/api/global.rs
+++ b/src/vim/api/global.rs
@@ -1,8 +1,38 @@
-#![cfg(feature = "unstable")]
-#![cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 use crate::prelude::*;
 
+/// Corresponds to `vim.api.nvim_get_current_buf`
+pub fn nvim_get_current_buf(lua: &Lua) -> LuaResult<i64> {
+    vim::api::get(lua)?.call_function("nvim_get_current_buf", ())
+}
+
+/// Corresponds to `vim.api.nvim_get_current_line`
+pub fn nvim_get_current_line(lua: &Lua) -> LuaResult<String> {
+    vim::api::get(lua)?.call_function("nvim_get_current_line", ())
+}
+
+/// Corresponds to `vim.api.nvim_get_current_tabpage`
+pub fn nvim_get_current_tabpage(lua: &Lua) -> LuaResult<i64> {
+    vim::api::get(lua)?.call_function("nvim_get_current_tabpage", ())
+}
+
+/// Corresponds to `vim.api.nvim_get_current_win`
+pub fn nvim_get_current_win(lua: &Lua) -> LuaResult<i64> {
+    vim::api::get(lua)?.call_function("nvim_get_current_win", ())
+}
+
+/// Corresponds to `vim.api.nvim_list_bufs`
+pub fn nvim_list_bufs(lua: &Lua) -> LuaResult<Vec<LuaInteger>> {
+    vim::api::get(lua)?.call_function("nvim_list_bufs", ())
+}
+
+/// Corresponds to `vim.api.nvim_exec`
+pub fn nvim_exec<'a>(lua: &'a Lua, cmd: &str, output: bool) -> LuaResult<LuaValue<'a>> {
+    vim::api::get(lua)?.call_function("nvim_exec", (cmd, output))
+}
+
 /// Corresponds to `vim.api.nvim_stats`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_stats(lua: &Lua) -> LuaResult<LuaTable> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_stats")?
@@ -10,6 +40,8 @@ pub fn nvim_stats(lua: &Lua) -> LuaResult<LuaTable> {
 }
 
 /// Corresponds to `vim.api.nvim_chan_send`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_chan_send(lua: &Lua, chan: i32, data: &str) -> LuaResult<()> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_chan_send")?
@@ -17,6 +49,8 @@ pub fn nvim_chan_send(lua: &Lua, chan: i32, data: &str) -> LuaResult<()> {
 }
 
 /// Corresponds to `vim.api.nvim_create_buf`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_create_buf(lua: &Lua, listed: bool, scratch: bool) -> LuaResult<i64> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_create_buf")?
@@ -24,6 +58,8 @@ pub fn nvim_create_buf(lua: &Lua, listed: bool, scratch: bool) -> LuaResult<i64>
 }
 
 /// Corresponds to `vim.api.nvim_del_current_line`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_del_current_line(lua: &Lua) -> LuaResult<()> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_del_current_line")?
@@ -31,6 +67,8 @@ pub fn nvim_del_current_line(lua: &Lua) -> LuaResult<()> {
 }
 
 /// Corresponds to `vim.api.nvim_del_keymap`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_del_keymap(lua: &Lua, mode: &str, lhs: &str) -> LuaResult<()> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_del_keymap")?
@@ -38,6 +76,8 @@ pub fn nvim_del_keymap(lua: &Lua, mode: &str, lhs: &str) -> LuaResult<()> {
 }
 
 /// Corresponds to `vim.api.nvim_del_mark`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_del_mark(lua: &Lua, name: &str) -> LuaResult<bool> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_del_mark")?
@@ -45,6 +85,8 @@ pub fn nvim_del_mark(lua: &Lua, name: &str) -> LuaResult<bool> {
 }
 
 /// Corresponds to `vim.api.nvim_del_var`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_del_var(lua: &Lua, name: &str) -> LuaResult<()> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_del_var")?
@@ -52,6 +94,8 @@ pub fn nvim_del_var(lua: &Lua, name: &str) -> LuaResult<()> {
 }
 
 /// Corresponds to `vim.api.nvim_echo`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_echo(
     lua: &Lua,
     chunks: LuaTable,
@@ -64,6 +108,8 @@ pub fn nvim_echo(
 }
 
 /// Corresponds to `vim.api.nvim_err_write`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_err_write(lua: &Lua, msg: &str) -> LuaResult<()> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_err_write")?
@@ -71,6 +117,8 @@ pub fn nvim_err_write(lua: &Lua, msg: &str) -> LuaResult<()> {
 }
 
 /// Corresponds to `vim.api.nvim_err_writeln`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_err_writeln(lua: &Lua, msg: &str) -> LuaResult<()> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_err_writeln")?
@@ -78,6 +126,8 @@ pub fn nvim_err_writeln(lua: &Lua, msg: &str) -> LuaResult<()> {
 }
 
 /// Options for `nvim_eval_statusline`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[derive(Debug)]
 pub struct EvalStatuslineOpt {
     winid: LuaInteger,
@@ -88,6 +138,8 @@ pub struct EvalStatuslineOpt {
     use_tabline: bool,
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<'a> ToLua<'a> for EvalStatuslineOpt {
     fn to_lua(self, lua: &'a Lua) -> LuaResult<LuaValue<'a>> {
         let table = lua.create_table()?;
@@ -102,6 +154,8 @@ impl<'a> ToLua<'a> for EvalStatuslineOpt {
 }
 
 /// Result of `nvim_eval_statusline`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[derive(Debug)]
 pub struct EvalStatuslineRes {
     pub str: String,
@@ -110,12 +164,16 @@ pub struct EvalStatuslineRes {
 }
 
 /// Highlight info for `nvim_eval_statusline`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[derive(Debug)]
 pub struct HighlightInfo {
     pub start: LuaInteger,
     pub group: String,
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<'a> FromLua<'a> for HighlightInfo {
     fn from_lua(lua_value: LuaValue<'a>, _lua: &'a Lua) -> LuaResult<Self> {
         match lua_value {
@@ -135,6 +193,8 @@ impl<'a> FromLua<'a> for HighlightInfo {
     }
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<'a> FromLua<'a> for EvalStatuslineRes {
     fn from_lua(lua_value: LuaValue<'a>, _lua: &'a Lua) -> LuaResult<Self> {
         match lua_value {
@@ -160,6 +220,8 @@ impl<'a> FromLua<'a> for EvalStatuslineRes {
 }
 
 /// Corresponds to `vim.api.nvim_eval_statusline`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_eval_statusline<'a>(
     lua: &'a Lua,
     expr: &str,
@@ -171,6 +233,8 @@ pub fn nvim_eval_statusline<'a>(
 }
 
 /// Corresponds to `vim.api.nvim_exec_lua`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_exec_lua<'a>(
     lua: &'a Lua,
     code: &str,
@@ -182,6 +246,8 @@ pub fn nvim_exec_lua<'a>(
 }
 
 /// Corresponds to `vim.api.nvim_feedkeys`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_feedkeys(lua: &Lua, keys: &str, mode: &str, escape_ks: bool) -> LuaResult<()> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_feedkeys")?
@@ -190,6 +256,8 @@ pub fn nvim_feedkeys(lua: &Lua, keys: &str, mode: &str, escape_ks: bool) -> LuaR
 
 /// Corresponds to `vim.api.nvim_get_api_info`
 // TODO: return type
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_api_info(lua: &Lua) -> LuaResult<(LuaInteger, LuaTable)> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_api_info")?
@@ -197,6 +265,8 @@ pub fn nvim_get_api_info(lua: &Lua) -> LuaResult<(LuaInteger, LuaTable)> {
 }
 
 /// Info struct for `nvim_get_chan_info`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[derive(Debug)]
 pub struct ChannelInfo<'a> {
     pub id: LuaInteger,
@@ -208,6 +278,8 @@ pub struct ChannelInfo<'a> {
     pub client: Option<LuaTable<'a>>,
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<'a> FromLua<'a> for ChannelInfo<'a> {
     fn from_lua(lua_value: LuaValue<'a>, _lua: &'a Lua) -> LuaResult<Self> {
         match lua_value {
@@ -241,6 +313,8 @@ impl<'a> FromLua<'a> for ChannelInfo<'a> {
 }
 
 /// Corresponds to `vim.api.nvim_get_chan_info`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_chan_info<'a>(lua: &'a Lua, chan: LuaInteger) -> LuaResult<ChannelInfo<'a>> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_chan_info")?
@@ -249,6 +323,8 @@ pub fn nvim_get_chan_info<'a>(lua: &'a Lua, chan: LuaInteger) -> LuaResult<Chann
 
 /// Corresponds to `vim.api.nvim_get_color_by_name`
 /// Returns 24-bit RGB value or -1 for invalid color.
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_color_by_name(lua: &Lua, name: &str) -> LuaResult<i64> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_color_by_name")?
@@ -257,51 +333,31 @@ pub fn nvim_get_color_by_name(lua: &Lua, name: &str) -> LuaResult<i64> {
 
 /// Corresponds to `vim.api.nvim_get_color_map`
 // TODO: return type
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_color_map(lua: &Lua) -> LuaResult<LuaTable> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_color_map")?
         .call(())
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub type GetContextOpt = Vec<String>;
 
 /// Corresponds to `vim.api.nvim_get_context`
 // TODO: return type
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_context(lua: &Lua, opt: Option<GetContextOpt>) -> LuaResult<LuaTable> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_context")?
         .call(opt)
 }
 
-/// Corresponds to `vim.api.nvim_get_current_buf`
-pub fn nvim_get_current_buf(lua: &Lua) -> LuaResult<i64> {
-    vim::api::get(lua)?
-        .get::<_, LuaFunction>("nvim_get_current_buf")?
-        .call(())
-}
-
-/// Corresponds to `vim.api.nvim_get_current_line`
-pub fn nvim_get_current_line(lua: &Lua) -> LuaResult<String> {
-    vim::api::get(lua)?
-        .get::<_, LuaFunction>("nvim_get_current_line")?
-        .call(())
-}
-
-/// Corresponds to `vim.api.nvim_get_current_tabpage`
-pub fn nvim_get_current_tabpage(lua: &Lua) -> LuaResult<i64> {
-    vim::api::get(lua)?
-        .get::<_, LuaFunction>("nvim_get_current_tabpage")?
-        .call(())
-}
-
-/// Corresponds to `vim.api.nvim_get_current_win`
-pub fn nvim_get_current_win(lua: &Lua) -> LuaResult<i64> {
-    vim::api::get(lua)?
-        .get::<_, LuaFunction>("nvim_get_current_win")?
-        .call(())
-}
-
 /// Corresponds to `vim.api.nvim_get_hl_by_id`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_hl_by_id<'a>(lua: &'a Lua, id: LuaInteger, rgb: bool) -> LuaResult<LuaTable<'a>> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_hl_by_id")?
@@ -309,6 +365,8 @@ pub fn nvim_get_hl_by_id<'a>(lua: &'a Lua, id: LuaInteger, rgb: bool) -> LuaResu
 }
 
 /// Corresponds to `vim.api.nvim_get_hl_by_name`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_hl_by_name<'a>(lua: &'a Lua, name: &str, rgb: bool) -> LuaResult<LuaTable<'a>> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_hl_by_name")?
@@ -316,6 +374,8 @@ pub fn nvim_get_hl_by_name<'a>(lua: &'a Lua, name: &str, rgb: bool) -> LuaResult
 }
 
 /// Corresponds to `vim.api.nvim_get_hl_id_by_name`
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_hl_id_by_name(lua: &Lua, name: &str) -> LuaResult<i64> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_hl_id_by_name")?
@@ -323,6 +383,8 @@ pub fn nvim_get_hl_id_by_name(lua: &Lua, name: &str) -> LuaResult<i64> {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub struct Mapping<'a> {
     pub buffer: LuaInteger,
     pub expr: LuaValue<'a>,
@@ -337,6 +399,8 @@ pub struct Mapping<'a> {
     pub silent: bool,
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<'a> FromLua<'a> for Mapping<'a> {
     fn from_lua(lua_value: LuaValue<'a>, _lua: &'a Lua) -> LuaResult<Self> {
         match lua_value {
@@ -377,12 +441,16 @@ impl<'a> FromLua<'a> for Mapping<'a> {
     }
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_keymap<'a>(lua: &'a Lua, mode: &str) -> LuaResult<Vec<Mapping<'a>>> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_keymap")?
         .call(mode)
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_mark(
     lua: &Lua,
     name: &str,
@@ -392,12 +460,16 @@ pub fn nvim_get_mark(
         .call(name)
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[derive(Debug)]
 pub struct GetModeRes {
     pub blocking: bool,
     pub mode: String,
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 impl<'a> FromLua<'a> for GetModeRes {
     fn from_lua(lua_value: LuaValue<'a>, _lua: &'a Lua) -> LuaResult<Self> {
         match lua_value {
@@ -417,29 +489,18 @@ impl<'a> FromLua<'a> for GetModeRes {
     }
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_mode(lua: &Lua) -> LuaResult<GetModeRes> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_mode")?
         .call(())
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub fn nvim_get_proc<'a>(lua: &'a Lua, pid: LuaInteger) -> LuaResult<LuaValue<'a>> {
     vim::api::get(lua)?
         .get::<_, LuaFunction>("nvim_get_proc")?
         .call(pid)
-}
-
-// TODO: nvim_get_proc_children
-// TODO: nvim_get_runtime_file
-// TODO: nvim_get_var
-// TOOD: nvim_get_vvar
-// TODO: nvim_input
-// TODO: nvim_input_mouse
-
-pub fn nvim_list_bufs(lua: &Lua) -> LuaResult<Vec<LuaInteger>> {
-    vim::api::get(lua)?.call_function("nvim_list_bufs", ())
-}
-
-pub fn nvim_exec<'a>(lua: &'a Lua, cmd: &str, output: bool) -> LuaResult<LuaValue<'a>> {
-    vim::api::get(lua)?.call_function("nvim_exec", (cmd, output))
 }

--- a/src/vim/api/mod.rs
+++ b/src/vim/api/mod.rs
@@ -1,8 +1,6 @@
 use crate::prelude::*;
 
-#[cfg(feature = "unstable")]
 mod global;
-#[cfg(feature = "unstable")]
 pub use global::*;
 
 mod buffer;


### PR DESCRIPTION
* `nvim_get_current_buf`
* `nvim_get_current_line`
* `nvim_get_current_tabpage`
* `nvim_get_current_win`
* `nvim_list_bufs`
* `nvim_exec`