### PR TITLE
fix: move rustflags for example template

### DIFF
--- a/examples/example-plugin/.cargo/config.toml
+++ b/examples/example-plugin/.cargo/config.toml
@@ -1,0 +1,7 @@
+# required config for dylibs on x86 macOS
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+# required config for dylibs on m1/m2 macOS
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/examples/example-plugin/Cargo.toml
+++ b/examples/example-plugin/Cargo.toml
@@ -7,23 +7,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-mlua = { version = "0.8.7", features = [
-  "luajit",
-  "vendored",
-  "module"
-]}
+mlua = { version = "0.8.7", features = ["luajit", "vendored", "module"] }
 nvim-utils = { path = "../../" }
-
-# required config for dylibs on x86 macOS
-[target.x86_64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
-
-# required config for dylibs on m1/m2 macOS
-[target.aarch64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]


### PR DESCRIPTION
This PR moves rustflags settings to `.cargo/config.toml`.

Related to https://github.com/willothy/moveline.nvim/pull/6